### PR TITLE
Make extensions public in favor or being available across modules

### DIFF
--- a/lib/redbreast/serializers/swift_serializer.rb
+++ b/lib/redbreast/serializers/swift_serializer.rb
@@ -50,11 +50,11 @@ module Redbreast
       end
 
       def generate_extension(extended_class, app_name)
-        text = 'extension ' + extended_class + " {\n"
+        text = 'public extension ' + extended_class + " {\n"
 
         return text if app_name.nil? || app_name.empty?
 
-        text + SPACER + "enum " + app_name + " {}\n}\n\nextension " + extended_class + '.' + app_name + " {"
+        text + SPACER + "enum " + app_name + " {}\n}\n\npublic extension " + extended_class + '.' + app_name + " {"
       end
 
       def create_swift_test_cases(names:, declaration:, app_name:)


### PR DESCRIPTION
The current implementation does not allow the usage of Assets across modules in a Modular architecture way.

Making namespace extensions public solves that issue.