### PR TITLE
Fix swiftui serializer

### DIFF
--- a/lib/redbreast/serializers/swiftui_serializer.rb
+++ b/lib/redbreast/serializers/swiftui_serializer.rb
@@ -65,7 +65,7 @@ module Redbreast
           temp_array = name.split('/')
           variable = temp_array.pop
           additional_text = temp_array.count.zero? ? '' : '.'
-          text += SPACER + SPACER + declaration + app_name_text + temp_array.join('.') + additional_text + clean_variable_name(variable)
+          text += SPACER + SPACER + declaration + app_name_text + temp_array.map { |enum| upper_camel_case(enum) }.join('.') + additional_text + clean_variable_name(variable)
           text += name == names.last ? '' : "\n"
         end
 


### PR DESCRIPTION
## Summary

The SwiftUI test template generates lowercase enum path segments (e.g. `Color.ProjectName.green.green20`) while the SwiftUI source template generates uppercase enum names (e.g. `enum Green`). This compiles in Xcode projects but fails in SPM packages.

The UIKit (Swift) serializer does NOT have this bug — it already applies `upper_camel_case`. In this PR, I've applied the same logic to fix the SwiftUI serializer.

**Related issue**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. --> N/A

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->

## Checklist

- [ ] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
